### PR TITLE
Document handling of recurring events without instances

### DIFF
--- a/technical_information.rst
+++ b/technical_information.rst
@@ -319,6 +319,8 @@ Exceptions of recurring events are identified by ``RECURRENCE-ID``. DAVx⁵ inse
    DAVx⁵ is not responsible for calculating the instances of a recurring event.
    It only provides ``RRULE``, ``RDATE``, ``EXRULE``, ``EXDATE`` and a list of exceptions to the Android calendar provider.
 
+   However, if a calendar app leaves dirty events *with zero instances* to be synced, DAVx⁵ will silently delete these events and ask the server to do the same. 
+
 
 Group-scheduled events
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Pretty simple, I think this should be the right place. @ArnyminerZ would you add anything?

For context: [this](https://github.com/bitfireAT/davx5/blob/bcc53eaac695b2094e07919e0b9adebad5352d3b/app/src/main/java/at/bitfire/davdroid/syncadapter/CalendarSyncManager.kt#L65) is happens in the code.